### PR TITLE
WIP: support for lsp next (lsp-register-client)

### DIFF
--- a/lsp-scala.el
+++ b/lsp-scala.el
@@ -49,6 +49,14 @@
                          (lambda () (sbt:find-root))
                          lsp-scala-server-command)
 
+(featurep 'lsp
+          (lsp-register-client
+           (make-lsp-client :new-connection (lsp-stdio-connection lsp-scala-server-command)
+                            :major-modes '(scala-mode)
+                            :server-id 'scala)
+           )
+          )
+
 (defun lsp-scala--run-from-root (orig &rest args)
   (let* ((client (car args))
          (lang-id (funcall (lsp--client-language-id client) (current-buffer))))

--- a/lsp-scala.el
+++ b/lsp-scala.el
@@ -33,6 +33,18 @@
 
 (add-hook 'lsp-after-initialize-hook 'lsp-scala--set-configuration)
 
+(defun lsp-scala-build-import ()
+  "Executes metals command build-import"
+  (interactive)
+  (lsp-send-execute-command "build-import" ())
+  )
+
+(defun lsp-scala-build-connect ()
+  "Executes metals command build-connect"
+  (interactive)
+  (lsp-send-execute-command "build-connect" ())
+  )
+
 (lsp-define-stdio-client lsp-scala "scala"
                          (lambda () (sbt:find-root))
                          lsp-scala-server-command)


### PR DESCRIPTION
Currently only the bare necessary to get lsp-scala running with lsp next. This uses lsp workspaces (derived from projectile) instead of sbt:find-root. I did not see a good place to integrate that. Still needed?

See also: https://github.com/emacs-lsp/lsp-mode/issues/479