### PR TITLE
Make work with unstable MELPA versions of lsp-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,30 @@ You must install the Emacs plugin (this) and a language server
 
 ### lsp-scala
 
-Install the `lsp-mode` and `sbt-mode` dependencies using your preferred package
-manager. Then clone this repo and load it:
+Clone this repo, and fetch `lsp-mode`, `lsp-ui`, and `sbt-mode` from
+MELPA with the package manager of your choice.  (We are working on
+adding this package to MELPA to make `lsp-scala` load like the rest.)
+Here is an example using `use-package`:
 
 ```emacs-lisp
-(add-to-list 'load-path "<path to lsp-scala>")
-(require 'lsp-scala)
-```
+(use-package lsp-mode
+  :ensure t)
 
-We are working on adding this package to MELPA to make this easier.
+(use-package lsp-scala
+  :load-path "~/path/to/lsp-scala"
+  :config
+  (setq lsp-scala-server-command "~/bin/metals-emacs")
+  (require 'lsp)
+  (add-hook 'scala-mode #'lsp))
+
+(use-package lsp-ui
+  :ensure t
+  :hook (lsp-mode . lsp-ui-mode))
+
+(use-package sbt-mode
+  :ensure t
+  :commands sbt-start sbt-command)
+```
 
 ### Language server
 
@@ -25,8 +40,8 @@ We are working on adding this package to MELPA to make this easier.
 Build a `metals-emacs` binary using the [Coursier] command line interface.
 
 ```sh
-# Make sure to use coursier v1.1.0-M9 or newer.
 curl -L -o coursier https://git.io/coursier
+METALS_VERSION=0.3.3
 chmod +x coursier
 ./coursier bootstrap \
   --java-opt -XX:+UseG1GC \
@@ -34,24 +49,26 @@ chmod +x coursier
   --java-opt -Xss4m \
   --java-opt -Xms1G \
   --java-opt -Xmx4G  \
-  --java-opt -Dmetals.client=lsp-emacs \
-  org.scalameta:metals_2.12:0.3.0 \
+  --java-opt -Dmetals.client=emacs \
+  org.scalameta:metals_2.12:${METALS_VERSION} \
   -r bintray:scalacenter/releases \
-  -r sonatype:releases \
-  -o metals-emacs -f
+  -r sonatype:snapshots \
+  -o /usr/local/bin/metals-emacs -f
 ```
 
 Put the resulting `metals-emacs` binary on your path.
 
 #### Other Scala language servers
 
-Other Scala language servers should work in theory.  The easiest way, if your server launches from the command line, is to customize `lsp-scala-server-command`.
+Other Scala language servers should work in theory.  The easiest way,
+if your server launches from the command line, is to customize
+`lsp-scala-server-command` and `lsp-scala-server-args`.
 
 ## Import a project
 
 ### SBT
 
-Open a `*.scala` file in your project and run `M-x lsp-scala-enable`.
+Open a `*.scala` file in your project and run `M-x lsp`.
 
 You will be prompted:
 
@@ -75,8 +92,13 @@ If all didn't go well, check the `.metals/metals.log` file.
 If you want `lsp-scala` to load for every scala file, add this:
 
 ```emacs-lisp
-(add-hook 'scala-mode-hook #'lsp-scala-enable)
+(add-hook 'scala-mode-hook #'lsp)
 ```
+
+## MELPA stable
+
+If you pin `lsp-mode` to MELPA stable, invoke the server with
+`lsp-scala-enable` rather than `lsp`.
 
 ## Does it work?
 

--- a/lsp-scala.el
+++ b/lsp-scala.el
@@ -68,7 +68,7 @@
 (eval-after-load 'lsp
   '(lsp-register-client
     (make-lsp-client :new-connection
-		     (lsp-stdio-connection (lambda () (lsp-scala--server-command)))
+           (lsp-stdio-connection 'lsp-scala--server-command)
 		     :major-modes '(scala-mode)
 		     :server-id 'scala)))
 

--- a/lsp-scala.el
+++ b/lsp-scala.el
@@ -8,7 +8,7 @@
 ;; Keywords: scala, lsp, metals
 ;; URL: https://github.com/rossabaker/lsp-scala
 
-;;; Commentary
+;;; Commentary:
 
 ;; This package defines an lsp-mode client for Scala.
 
@@ -19,12 +19,12 @@
 
 ;;;###autoload
 (defcustom lsp-scala-server-command '("metals-emacs")
-  "The command to launch the language server,"
+  "The command to launch the language server."
   :group 'lsp-scala
   :type 'list)
 
 (defcustom lsp-scala-workspace-root default-directory
-  "The root directory of the workspace,"
+  "The root directory of the workspace."
   :group 'lsp-scala
   :type 'directory)
 

--- a/lsp-scala.el
+++ b/lsp-scala.el
@@ -18,10 +18,20 @@
 (require 'sbt-mode)
 
 ;;;###autoload
-(defcustom lsp-scala-server-command '("metals-emacs")
-  "The command to launch the language server."
+(defcustom lsp-scala-server-command "metals-emacs"
+  "The command to launch the Scala language server."
   :group 'lsp-scala
-  :type 'list)
+  :type 'file)
+
+;;;###autoload
+(defcustom lsp-scala-server-args '()
+  "Extra arguments for the Scala language server."
+  :group 'lsp-scala
+  :type '(repeat string))
+
+(defun lsp-scala--server-command ()
+  "Generate the Scala language server startup command."
+  `(,lsp-scala-server-command ,@lsp-scala-server-args))
 
 (defvar lsp-scala--config-options `())
 
@@ -55,9 +65,17 @@
   (lsp-send-execute-command "source-scan" ())
   )
 
+(eval-after-load 'lsp
+  '(lsp-register-client
+    (make-lsp-client :new-connection
+		     (lsp-stdio-connection (lambda () (lsp-scala--server-command)))
+		     :major-modes '(scala-mode)
+		     :server-id 'scala)))
+
+;; Legacy support for lsp-mode <= 5
 (lsp-define-stdio-client lsp-scala "scala"
                          (lambda () (sbt:find-root))
-                         lsp-scala-server-command)
+                         (lsp-scala--server-command))
 
 (provide 'lsp-scala)
 ;;; lsp-scala.el ends here

--- a/lsp-scala.el
+++ b/lsp-scala.el
@@ -23,11 +23,6 @@
   :group 'lsp-scala
   :type 'list)
 
-(defcustom lsp-scala-workspace-root default-directory
-  "The root directory of the workspace."
-  :group 'lsp-scala
-  :type 'directory)
-
 (defvar lsp-scala--config-options `())
 
 (defun lsp-scala--set-configuration ()


### PR DESCRIPTION
Calls `'lsp-register-client` after `'lsp` is loaded.  On MELPA stable, this symbol doesn't exist.  Still calls the legacy `lsp-enable-scala, so the same package works on both MELPA stable and unstable.

Cleaned up some issues with flycheck so we can submit to MELPA.

Subsumes #9.

/cc @coreyoconnor @olafurpg 