### PR TITLE
Invoke legacy lsp-define-stdio-client only if it is defined

### DIFF
--- a/lsp-scala.el
+++ b/lsp-scala.el
@@ -69,9 +69,10 @@
 		     :server-id 'scala)))
 
 ;; Legacy support for lsp-mode <= 5
-(lsp-define-stdio-client lsp-scala "scala"
-                         (lambda () (sbt:find-root))
-                         (lsp-scala--server-command))
+(when (fboundp 'lsp-define-stdio-client)
+  (lsp-define-stdio-client lsp-scala "scala"
+                           (lambda () (sbt:find-root))
+                           (lsp-scala--server-command)))
 
 (provide 'lsp-scala)
 ;;; lsp-scala.el ends here


### PR DESCRIPTION
To avoid getting this error when loading lsp-scala: `Symbol’s function
definition is void: lsp-define-stdio-client`

I got the error above with lsp-mode from melpa, version 20190115.1237.

lsp-define-stdio-client seems to have been removed in
https://github.com/emacs-lsp/lsp-mode/commit/ec0baa1