### PR TITLE
Drop legacy lsp-mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ You must install the Emacs plugin (this) and a language server
 Clone this repo, and fetch `lsp-mode`, `lsp-ui`, and `sbt-mode` from
 MELPA with the package manager of your choice.  (We are working on
 adding this package to MELPA to make `lsp-scala` load like the rest.)
+
+This package no longer works with the "legacy lsp-mode" currently in
+MELPA stable.  Be sure to use unpin from stable when installing
+`lsp-mode` and `lsp-ui`.
+
 Here is an example using `use-package`:
 
 ```emacs-lisp

--- a/lsp-scala.el
+++ b/lsp-scala.el
@@ -61,18 +61,11 @@
   (interactive)
   (lsp-send-execute-command "source-scan" ()))
 
-(with-eval-after-load 'lsp
-  (lsp-register-client
-    (make-lsp-client :new-connection
-           (lsp-stdio-connection 'lsp-scala--server-command)
-		     :major-modes '(scala-mode)
-		     :server-id 'scala)))
-
-;; Legacy support for lsp-mode <= 5
-(when (fboundp 'lsp-define-stdio-client)
-  (lsp-define-stdio-client lsp-scala "scala"
-                           (lambda () (sbt:find-root))
-                           (lsp-scala--server-command)))
+(lsp-register-client
+ (make-lsp-client :new-connection
+		  (lsp-stdio-connection 'lsp-scala--server-command)
+		  :major-modes '(scala-mode)
+		  :server-id 'scala))
 
 (provide 'lsp-scala)
 ;;; lsp-scala.el ends here


### PR DESCRIPTION
Trying to support both versions caused #17 and got https://github.com/melpa/melpa/pull/5868 stuck in the mud.  This simplifies the package to only support MELPA unstable.